### PR TITLE
compatibility with Julia 1.0 and lsp-mode

### DIFF
--- a/README.org
+++ b/README.org
@@ -3,7 +3,7 @@
 Julia support for the [[https://github.com/emacs-lsp/lsp-mode][=lsp-mode=]] package using the [[https://github.com/JuliaEditorSupport/LanguageServer.jl][LanguageServer.jl]] package.
 For information on the features =lsp-mode= provides see their [[https://github.com/emacs-lsp/lsp-mode][git repository]].
 
-/A julia version == 0.6.x has to be in your path/
+/A julia version 1.0 or higher has to be in your path/
 
 /This package is still under development./
 

--- a/lsp-julia.el
+++ b/lsp-julia.el
@@ -13,6 +13,11 @@
 ;;; Code:
 (require 'lsp-mode)
 
+(defcustom lsp-julia-default-environment "~/.julia/environments/v1.0"
+  "The path to the default environment."
+  :type 'string
+  :group 'lsp-julia)
+
 (defcustom lsp-julia-command "julia"
   "Command to invoke julia with."
   :type 'string
@@ -25,19 +30,34 @@
 
 (defcustom lsp-julia-timeout 30
   "Time before lsp-mode should assume julia just ain't gonna start."
+  :type 'number
+  :group 'lsp-julia)
+
+(defcustom lsp-julia-default-depot ""
+  "The default depot path, used if `JULIA_DEPOT_PATH' is unset"
+  :type 'string
   :group 'lsp-julia)
 
 (defun lsp-julia--get-root ()
-  "Try to find the package directory by searching for a .gitignore file.
-If no .gitignore file can be found use the default directory "
-  (let ((dir (locate-dominating-file default-directory ".gitignore")))
-    (if dir
-        (expand-file-name dir)
-      default-directory)))
+  (let ((dir (locate-dominating-file default-directory "Project.toml")))
+    (if dir (expand-file-name dir)
+      (expand-file-name lsp-julia-default-environment))))
+
+(defun lsp-julia--get-depot-path ()
+  (let ((dp (getenv "JULIA_DEPOT_PATH")))
+    (if dp dp lsp-julia-default-depot)))
 
 (defun lsp-julia--rls-command ()
-  `(,lsp-julia-command ,@lsp-julia-flags "-e using LanguageServer; server = LanguageServer.LanguageServerInstance(STDIN, STDOUT, false); server.runlinter = true; run(server);"))
-
+  `(,lsp-julia-command
+    ,@lsp-julia-flags
+    ,(concat "-e using LanguageServer, Sockets, SymbolServer;"
+             " server = LanguageServer.LanguageServerInstance("
+             " stdin, stdout, false,"
+             " \"" (lsp-julia--get-root) "\","
+             " \"" (lsp-julia--get-depot-path) "\","
+             "Dict());"
+             " server.runlinter = true;"
+             " run(server);")))
 
 (defconst lsp-julia--handlers
   '(("window/setStatusBusy" .
@@ -45,13 +65,10 @@ If no .gitignore file can be found use the default directory "
     ("window/setStatusReady" .
      (lambda(w _p)))))
 
-(defun lsp-julia--initialize-client(client)
-  (mapcar #'(lambda (p) (lsp-client-on-notification client (car p) (cdr p))) lsp-julia--handlers)
-  (setq-local lsp-response-timeout lsp-julia-timeout))
-
-(lsp-define-stdio-client lsp-julia "julia" #'lsp-julia--get-root nil
-                         :command-fn #'lsp-julia--rls-command
-                         :initialize #'lsp-julia--initialize-client)
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection 'lsp-julia--rls-command)
+                  :major-modes '(julia-mode)
+                  :server-id 'julia-ls))
 
 (provide 'lsp-julia)
 ;;; lsp-julia.el ends here


### PR DESCRIPTION
Fixes #3 and #4.

In spacemacs you have to my fork of  spacemacs/develop: https://github.com/gdkrmr/spacemacs.git and set
```elisp
(setq  dotspacemacs-configuration-layers
       ...
       '(lsp :variables
             lsp-prefer-flymake nil)
       ...)
```
because there is no integration with flymake.
You have to use a Julia 1.0 compatible version of `LanguageServer.jl`


