### PR TITLE
Update default Julia environment and SymbolServer versions

### DIFF
--- a/lsp-julia.el
+++ b/lsp-julia.el
@@ -62,7 +62,7 @@ Set to nil if you want to use the globally installed versions."
   :type 'string
   :group 'lsp-julia)
 
-(defcustom lsp-julia-default-environment "~/.julia/environments/v1.0"
+(defcustom lsp-julia-default-environment "~/.julia/environments/v1.2"
   "The path to the default environment."
   :type 'string
   :group 'lsp-julia)


### PR DESCRIPTION
The Julia version (1.0 -> 1.2) is for convenience (latest stable release). The SymbolServer version is the most recent (0.2.4 -> 0.2.5) due to the previous version throwing errors for me.