### PR TITLE
Simplify invocation of language server

### DIFF
--- a/lsp-julia.el
+++ b/lsp-julia.el
@@ -107,13 +107,12 @@ Set to nil if you want to use the globally installed versions."
   "The command to lauch the Julia Language Server."
   `(,lsp-julia-command
     ,@lsp-julia-flags
-    ,(concat "-e using LanguageServer, Sockets, SymbolServer;"
-             " server = LanguageServer.LanguageServerInstance("
+    ,(concat "-e using LanguageServer;"
+             " server = LanguageServerInstance("
              " stdin, stdout, false,"
              " \"" (lsp-julia--get-root) "\","
              " \"" (lsp-julia--get-depot-path) "\","
              "Dict());"
-             " server.runlinter = true;"
              " run(server);")))
 
 (defconst lsp-julia--handlers


### PR DESCRIPTION
- Only LanguageServer needs to be in scope.
- LanguageServerInstance is now exported.
- server.runlinter is set to true by default.

I thought this might make the code a little nicer to read and see what's going on for outside contributors.

@gdkrmr the merge is up to you. Also, if you're going to maintain this package, you should probably go ahead and "watch" it on github. There's a couple of PRs other than mine.