### PR TITLE
add ess-julia-mode to major-mode list

### DIFF
--- a/lsp-julia.el
+++ b/lsp-julia.el
@@ -124,7 +124,7 @@ Set to nil if you want to use the globally installed versions."
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection 'lsp-julia--rls-command)
-                  :major-modes '(julia-mode)
+                  :major-modes '(julia-mode ess-julia-mode)
                   :server-id 'julia-ls))
 
 (provide 'lsp-julia)


### PR DESCRIPTION
This allows to use `lsp-julia` in `ess-julia-mode`. This feature was requested in #8. `ess-julia-mode` was added in language-id list in https://github.com/emacs-lsp/lsp-mode/pull/1677.