### PR TITLE
Add support for Julia environment inside a subdirectory

### DIFF
--- a/lsp-julia.el
+++ b/lsp-julia.el
@@ -252,8 +252,8 @@ body."
   "Get the (Julia) project root directory of the current file."
   (concat "\""
           (expand-file-name
-           (or (locate-dominating-file default-directory "Project.toml")
-               (locate-dominating-file default-directory "JuliaProject.toml")
+           (or (locate-dominating-file buffer-file-name "Project.toml")
+               (locate-dominating-file buffer-file-name "JuliaProject.toml")
                lsp-julia-default-environment))
           "\""))
 


### PR DESCRIPTION
`lsp-mode` [overrides default directory](https://github.com/emacs-lsp/lsp-mode/blob/eb0c79918c7c8011d417d120ab4d603bd2f606c1/lsp-mode.el#L7160) to be the project root
directory upon start so that a Julia environment residing in a
subdirectory won't be picked up. A better alternative could be just
start looking for an environment root starting from the current file
if available.

---
One assumption I made is that LSP always started from file visiting buffer. If it is not the case (couldn't think of any counter-example), then additional logic is needed.
